### PR TITLE
feat: Add Ollama API compatibility for embeddings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,7 @@ ENV EMBEDDINGS_CACHE_ENABLED=true
 ENV EMBEDDINGS_CACHE_MAXSIZE=2048
 ENV REPORT_CACHED_TOKENS=false
 
-CMD ["uvicorn", "app:app", "--host", "${APP_HOST}", "--port", "${APP_PORT}"]
-# CMD ["python", "app.py"]
+COPY --chown=user --chmod=755 entrypoint.sh /app/entrypoint.sh
+
+EXPOSE 7860
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Python Version](https://img.shields.io/badge/Python-3.10%2B-blue)
 [![codecov](https://codecov.io/gh/atrifat/text-embedding-api/branch/main/graph/badge.svg)](https://codecov.io/gh/atrifat/text-embedding-api)
 
-A Text Embedding API server built with FastAPI and Hugging Face Transformers, designed to be compatible with OpenAI's Embeddings API format.
+A Text Embedding API server built with FastAPI and Hugging Face Transformers, designed to be compatible with OpenAI's and Ollama's Embeddings API formats.
 
 ## Features
 
@@ -11,7 +11,7 @@ A Text Embedding API server built with FastAPI and Hugging Face Transformers, de
 - **Hugging Face Transformers Integration**: Supports various pre-trained transformer models for generating embeddings.
 - **Model and Embeddings Caching**: Includes in-memory caches for loaded models, tokenizers, and generated embeddings to help improve response times.
 - **Batch Processing**: Processes multiple text inputs in configurable batches.
-- **OpenAI API Compatibility**: The `/v1/embeddings` endpoint is designed to be compatible with the OpenAI Embeddings API.
+- **OpenAI and Ollama API Compatibility**: The `/v1/embeddings` endpoint is compatible with the OpenAI Embeddings API, and the `/api/embed` endpoint is compatible with the Ollama Embeddings API.
 
 ## Architecture Overview
 
@@ -178,7 +178,7 @@ Or for multiple inputs:
 }
 ```
 
-**Example Response:**
+**Example Response (`/v1/embeddings` - OpenAI-compatible):**
 
 ```json
 {
@@ -194,6 +194,23 @@ Or for multiple inputs:
   "usage": {
     "prompt_tokens": 10,
     "total_tokens": 10
+  }
+}
+```
+
+**Example Response (`/api/embed` - Ollama-compatible):**
+
+```json
+{
+  "embeddings": [
+    [
+      -0.006929283495992422,
+      -0.005336422007530928
+    ]
+  ],
+  "usage": {
+    "promptTokens": 5,
+    "totalTokens": 5
   }
 }
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec uvicorn app:app --host "${APP_HOST:-0.0.0.0}" --port "${APP_PORT:-7860}" "$@"


### PR DESCRIPTION
This PR introduces compatibility with the Ollama embeddings API, allowing the server to serve embedding requests in both OpenAI-compatible and Ollama-compatible formats from distinct endpoints. This enhancement broadens the utility of the embedding server by supporting a wider range of client integrations.

Key components of this change include:

- Introduction of a new Pydantic model (`OllamaEmbeddingResponse`) to define the Ollama-specific response structure.
- Modification of the `create_embeddings` endpoint to dynamically format responses based on the incoming request path (`/v1/embeddings` for OpenAI, `/api/embed` for Ollama).
- Addition of an `entrypoint.sh` script and corresponding `Dockerfile` updates to standardize Docker container execution.
- Add tests to validate the new Ollama-compatible output and ensure correct handling of various input scenarios.
- Updates to the `README.md` to reflect the new Ollama API example response and explicitly mention Ollama compatibility in the features.