### PR TITLE
ci: Refine Docker image tagging in build workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,8 +36,11 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=sha,format=long,prefix=
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=ref,event=branch,pattern=main
+            type=ref,event=branch,pattern=dev
+            type=ref,event=branch,pattern=v0.1
             type=ref,event=tag,pattern=v(.*)
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && contains(github.ref_name, '.') }}
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This PR refines the Docker image tagging strategy within the `.github/workflows/build-docker.yml` workflow.

The changes include:
- Updating the `latest` tag logic to apply only to semantic version tags (e.g., `v1.0.0`) that are pushed as Git tags.
- Introducing explicit tagging for `main` and `dev` branches, ensuring dedicated image tags for these development lines.

These adjustments provide more precise and predictable Docker image tagging, aligning with common release and development practices.