### PR TITLE
refactor: Standardize API response formatting and centralize schemas

### DIFF
--- a/response_formatter.py
+++ b/response_formatter.py
@@ -1,0 +1,30 @@
+import logging
+from typing import List
+
+import torch
+
+from schemas import EmbeddingObject, EmbeddingResponse, OllamaEmbeddingResponse
+
+logger = logging.getLogger(__name__)
+
+
+def format_openai_response(
+    embeddings_tensor: torch.Tensor, total_tokens: int, texts: List[str], model_name: str
+) -> EmbeddingResponse:
+    """
+    Constructs an OpenAI-compatible EmbeddingResponse.
+    """
+    data = [EmbeddingObject(embedding=embeddings_tensor[i].tolist(), index=i) for i in range(len(texts))]
+    usage = {
+        "prompt_tokens": total_tokens,
+        "total_tokens": total_tokens,
+    }
+    return EmbeddingResponse(data=data, model=model_name, object="list", usage=usage)
+
+
+def format_ollama_response(embeddings_tensor: torch.Tensor, total_tokens: int) -> OllamaEmbeddingResponse:
+    """
+    Constructs an Ollama-compatible OllamaEmbeddingResponse.
+    """
+    usage_data = {"promptTokens": total_tokens, "totalTokens": total_tokens}
+    return OllamaEmbeddingResponse(embeddings=embeddings_tensor.tolist(), usage=usage_data)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,126 @@
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
+
+from models_config import CANONICAL_MODELS, MODEL_ALIASES, MODELS
+
+
+class EmbeddingRequest(BaseModel):
+    """
+    Represents a request for generating embeddings.
+
+    Attributes:
+        input (Union[str, List[str]]): The input text to embed, can be a single string or a list of strings.
+        model (str): The name of the model to use for embedding.
+        encoding_format (str): The format of the embeddings. Currently only 'float' is supported.
+    """
+
+    input: Union[str, List[str]] = Field(
+        ...,
+        description="The input text to embed, can be a single string or a list of strings.",
+        json_schema_extra={"example": "This is an example sentence."},
+    )
+    model: str = Field(
+        "text-embedding-3-large",
+        description=(
+            "The name of the model to use for embedding. Supports both original model names "
+            "and OpenAI-compatible names."
+        ),
+        json_schema_extra={"example": "text-embedding-3-large"},
+    )
+    encoding_format: str = Field(
+        "float",
+        description="The format of the embeddings. Currently only 'float' is supported.",
+        json_schema_extra={"example": "float"},
+    )
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        if value not in MODELS:
+            valid_models = list(CANONICAL_MODELS.keys()) + list(MODEL_ALIASES.keys())
+            raise ValueError(f"Model must be one of: {', '.join(sorted(valid_models))}")
+        return value
+
+    @field_validator("encoding_format")
+    @classmethod
+    def validate_encoding_format(cls, value: str) -> str:
+        if value != "float":
+            raise ValueError("Only 'float' encoding format is supported")
+        return value
+
+
+class EmbeddingObject(BaseModel):
+    """
+    Represents an embedding object.
+
+    Attributes:
+        object (str): The type of object, which is "embedding".
+        embedding (List[float]): The embedding vector.
+        index (int): The index of the embedding.
+    """
+
+    object: str = "embedding"
+    embedding: List[float]
+    index: int
+
+
+class EmbeddingResponse(BaseModel):
+    """
+    Represents the response containing a list of embedding objects.
+    """
+
+    data: List[EmbeddingObject]
+    model: str
+    object: str = "list"
+    usage: dict
+
+
+class OllamaEmbeddingResponse(BaseModel):
+    """
+    Represents the response containing a list of embedding vectors in Ollama's format,
+    with an optional usage field.
+    """
+
+    embeddings: List[List[float]]
+    usage: Optional[dict] = {}
+
+
+class ModelObject(BaseModel):
+    """
+    Represents a single model object in the list of models.
+    """
+
+    id: str
+    object: str = "model"
+    created: int
+    owned_by: str
+
+
+class ListModelsResponse(BaseModel):
+    """
+    Represents the response containing a list of available models.
+    """
+
+    data: List[ModelObject]
+    object: str = "list"
+
+
+class OllamaModelDetails(BaseModel):
+    format: str = "gguf"  # Placeholder, as HF models are not necessarily GGUF
+    family: str
+    families: List[str]
+    parameter_size: str
+    quantization_level: str
+
+
+class OllamaModelObject(BaseModel):
+    name: str
+    modified_at: str
+    size: int
+    digest: str
+    details: OllamaModelDetails
+
+
+class OllamaTagsResponse(BaseModel):
+    models: List[OllamaModelObject]

--- a/test_response_formatter.py
+++ b/test_response_formatter.py
@@ -1,0 +1,103 @@
+import pytest
+import torch
+
+from response_formatter import format_ollama_response, format_openai_response
+from schemas import EmbeddingResponse, OllamaEmbeddingResponse
+
+
+@pytest.fixture
+def mock_embeddings_tensor():
+    """Fixture for a mock embeddings tensor."""
+    return torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+
+@pytest.fixture
+def mock_single_embedding_tensor():
+    """Fixture for a mock single embedding tensor."""
+    return torch.tensor([[0.7, 0.8, 0.9]])
+
+
+def test_format_openai_response_single_text(mock_single_embedding_tensor):
+    """Test OpenAI response formatting with a single text input."""
+    texts = ["test sentence"]
+    model_name = "test-model"
+    total_tokens = 5
+
+    response = format_openai_response(mock_single_embedding_tensor, total_tokens, texts, model_name)
+
+    assert isinstance(response, EmbeddingResponse)
+    assert len(response.data) == 1
+    assert response.data[0].embedding == mock_single_embedding_tensor[0].tolist()
+    assert response.data[0].index == 0
+    assert response.model == model_name
+    assert response.object == "list"
+    assert response.usage == {"prompt_tokens": total_tokens, "total_tokens": total_tokens}
+
+
+def test_format_openai_response_multiple_texts(mock_embeddings_tensor):
+    """Test OpenAI response formatting with multiple text inputs."""
+    texts = ["sentence one", "sentence two"]
+    model_name = "another-model"
+    total_tokens = 10
+
+    response = format_openai_response(mock_embeddings_tensor, total_tokens, texts, model_name)
+
+    assert isinstance(response, EmbeddingResponse)
+    assert len(response.data) == 2
+    assert response.data[0].embedding == mock_embeddings_tensor[0].tolist()
+    assert response.data[0].index == 0
+    assert response.data[1].embedding == mock_embeddings_tensor[1].tolist()
+    assert response.data[1].index == 1
+    assert response.model == model_name
+    assert response.object == "list"
+    assert response.usage == {"prompt_tokens": total_tokens, "total_tokens": total_tokens}
+
+
+def test_format_openai_response_empty_input():
+    """Test OpenAI response formatting with empty input."""
+    texts = []
+    model_name = "empty-model"
+    total_tokens = 0
+    empty_tensor = torch.empty(0, 0)
+
+    response = format_openai_response(empty_tensor, total_tokens, texts, model_name)
+
+    assert isinstance(response, EmbeddingResponse)
+    assert len(response.data) == 0
+    assert response.model == model_name
+    assert response.object == "list"
+    assert response.usage == {"prompt_tokens": 0, "total_tokens": 0}
+
+
+def test_format_ollama_response_single_embedding(mock_single_embedding_tensor):
+    """Test Ollama response formatting with a single embedding."""
+    total_tokens = 5
+
+    response = format_ollama_response(mock_single_embedding_tensor, total_tokens)
+
+    assert isinstance(response, OllamaEmbeddingResponse)
+    assert response.embeddings == mock_single_embedding_tensor.tolist()
+    assert response.usage == {"promptTokens": total_tokens, "totalTokens": total_tokens}
+
+
+def test_format_ollama_response_multiple_embeddings(mock_embeddings_tensor):
+    """Test Ollama response formatting with multiple embeddings."""
+    total_tokens = 10
+
+    response = format_ollama_response(mock_embeddings_tensor, total_tokens)
+
+    assert isinstance(response, OllamaEmbeddingResponse)
+    assert response.embeddings == mock_embeddings_tensor.tolist()
+    assert response.usage == {"promptTokens": total_tokens, "totalTokens": total_tokens}
+
+
+def test_format_ollama_response_empty_input():
+    """Test Ollama response formatting with empty input."""
+    total_tokens = 0
+    empty_tensor = torch.empty(0, 0)
+
+    response = format_ollama_response(empty_tensor, total_tokens)
+
+    assert isinstance(response, OllamaEmbeddingResponse)
+    assert response.embeddings == []
+    assert response.usage == {"promptTokens": 0, "totalTokens": 0}


### PR DESCRIPTION
This PR refactors the Text Embedding API to standardize response formatting and centralize Pydantic schemas, improving modularity, maintainability, and extensibility.

Key changes include:
- **Centralized Pydantic Models:** Moved all API-related Pydantic models from `app.py` to a new `schemas.py` file for better organization and reusability.
- **Dedicated Response Formatting Module:** Introduced `response_formatter.py` with functions (`format_openai_response`, `format_ollama_response`) to abstract and encapsulate the logic for generating different API response formats.
- **Simplified `app.py` Endpoint:** The `create_embeddings` endpoint in `app.py` was refactored to delegate response construction to the new `response_formatter.py` functions, reducing conditional logic and improving readability.
- **Updated Testing:** Added new unit tests in `test_response_formatter.py` to ensure the correctness of the new formatting functions.